### PR TITLE
Simplify Default Constructor

### DIFF
--- a/daemon.go
+++ b/daemon.go
@@ -63,7 +63,11 @@ type Options struct {
 }
 
 // New returns an instance of a Daemon.
-func New(opt *Options) *Daemon {
+func New(proc Runner) *Daemon {
+	return NewWithOptions(&Options{Proc: proc})
+}
+
+func NewWithOptions(opt *Options) *Daemon {
 	if opt.Proc == nil {
 		panic(ErrInvalidProc)
 	}

--- a/daemon.go
+++ b/daemon.go
@@ -11,6 +11,7 @@ import (
 	"github.com/pkg/errors"
 )
 
+// Errors returned by daemon.
 var (
 	ErrInvalidProc = errors.New("invalid process")
 	ErrInvalidChan = errors.New("invalid channel")
@@ -67,6 +68,7 @@ func New(proc Runner) *Daemon {
 	return NewWithOptions(&Options{Proc: proc})
 }
 
+// NewWithOptions creates an instance of Daemon based on given opt.
 func NewWithOptions(opt *Options) *Daemon {
 	if opt.Proc == nil {
 		panic(ErrInvalidProc)


### PR DESCRIPTION
This PR introduces the following:

- `New` now accepts only `Runner`
- `NewWithOptions` can be used to create a daemon with extra options

