### PR TITLE
Create Constuctor for Service and Use Pointer Semantics

### DIFF
--- a/daemon.go
+++ b/daemon.go
@@ -38,8 +38,15 @@ type Service struct {
 	Cmd func() error
 }
 
+// NewService returns a new service created from a passed function.
+func NewService(f func() error) *Service {
+	return &Service{
+		Cmd: f,
+	}
+}
+
 // Run wraps Cmd.
-func (s Service) Run() error {
+func (s *Service) Run() error {
 	return s.Cmd()
 }
 


### PR DESCRIPTION
This PR introduces two minor changes to the library:
1. Use pointer semantics for the `Service` type.
Instead of a value, it now operates on a pointer receiver.
2.  The `NewService` constructor is introduced to simplify service creation for simple use cases when a sevice to be run is represented as a single function.
