### PR TITLE
fix: address possible deadlock

### DIFF
--- a/daemon.go
+++ b/daemon.go
@@ -45,7 +45,11 @@ func runWithSigCn(ctx context.Context, svc service, sigs chan os.Signal) error {
 	case <-sigs:
 		rcancel()
 
-		<-errs
+		// Check if Run has returned.
+		select {
+		case <-errs:
+		default:
+		}
 
 		sctx, cancel := context.WithTimeout(ctx, svc.Timeout())
 		defer cancel()
@@ -102,10 +106,6 @@ type Service struct {
 }
 
 // Run runs s.
-//
-// The supplied implementation for RunFn should regularly check ctx if it's done or not.
-//
-// When ctx is cancelled, RunFn must return.
 func (s *Service) Run(ctx context.Context) error {
 	if s.RunFn == nil {
 		tck := time.NewTicker(100 * time.Millisecond)


### PR DESCRIPTION
This PR updates `Run` so it does not block in the shutdown sequence under certain conditions.

Specifically, there is no guarantee that the supplied service's `Run` method would return upon context cancellation. So instead of assuming it would, we now make a best effort to get the error, or carry on with the shutdown sequence.